### PR TITLE
Add env file support for Tuya token script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+TUYA_CLIENT_ID=your_client_id
+TUYA_CLIENT_SECRET=your_client_secret
+# Optional: override region (eu, us, cn, etc.)
+#TUYA_REGION=eu

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+node_modules/

--- a/README.md
+++ b/README.md
@@ -45,3 +45,24 @@ Kan videreutvikles med flere effekter, farger, dashboards og integrasjoner.
 
 Oppsummering
 Avo Demometer er et eksempel på hvordan fysiske, digitale og skybaserte løsninger kan spille sammen for å skape både innsikt, synlighet og engasjement på arbeidsplassen – hele veien fra CRM, via automasjon, til fysisk visualisering og selvhelbredende teknologi.
+
+## Hente access token fra Tuya med Node.js
+
+For å hente en access token programmatisk kan du bruke skriptet `get_tuya_token.js` i dette repoet. Du kan enten sette miljøvariablene manuelt eller legge dem i en `.env`‑fil.
+
+1. Kopier `.env.example` til `.env` og fyll inn dine egne verdier.
+
+```bash
+cp .env.example .env
+# eller sett variablene direkte
+export TUYA_CLIENT_ID=din_client_id
+export TUYA_CLIENT_SECRET=din_client_secret
+```
+
+Kjør deretter skriptet:
+
+```bash
+node get_tuya_token.js
+```
+
+Skriptet beregner signaturen i henhold til Tuyas dokumentasjon og sender forespørselen til `https://openapi.tuya{region}.com/v1.0/token?grant_type=1`. Regionen kan settes via `TUYA_REGION` (f.eks. `eu`, `us` eller `cn`).

--- a/get_tuya_token.js
+++ b/get_tuya_token.js
@@ -1,0 +1,71 @@
+const crypto = require('crypto');
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+
+function loadEnvFile(file) {
+  try {
+    const data = fs.readFileSync(file, 'utf8');
+    data.split(/\r?\n/).forEach(line => {
+      const match = line.match(/^\s*([\w.-]+)\s*=\s*(.*)\s*$/);
+      if (match) {
+        const key = match[1];
+        let value = match[2];
+        if (value.startsWith('"') && value.endsWith('"')) {
+          value = value.slice(1, -1);
+        }
+        if (process.env[key] === undefined) {
+          process.env[key] = value;
+        }
+      }
+    });
+  } catch (err) {
+    // ignore if .env does not exist
+  }
+}
+
+loadEnvFile(path.join(__dirname, '.env'));
+
+const region = process.env.TUYA_REGION || 'eu';
+const clientId = process.env.TUYA_CLIENT_ID;
+const secret = process.env.TUYA_CLIENT_SECRET;
+
+if (!clientId || !secret) {
+  console.error('Set TUYA_CLIENT_ID and TUYA_CLIENT_SECRET environment variables');
+  process.exit(1);
+}
+
+const HTTP_METHOD = 'GET';
+const PATH_WITH_QUERY = '/v1.0/token?grant_type=1';
+const NULL_HASH = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+
+const t = Date.now().toString();
+const stringToSign = [HTTP_METHOD, NULL_HASH, '', PATH_WITH_QUERY].join('\n');
+const str = clientId + t + '' + stringToSign;
+
+const hmac = crypto.createHmac('sha256', secret);
+hmac.update(str);
+const signature = hmac.digest('hex').toUpperCase();
+
+const options = {
+  hostname: `openapi.tuya${region}.com`,
+  path: PATH_WITH_QUERY,
+  method: HTTP_METHOD,
+  headers: {
+    'client_id': clientId,
+    't': t,
+    'sign_method': 'HMAC-SHA256',
+    'sign': signature
+  }
+};
+
+console.log('Request options:', options);
+
+const req = https.request(options, res => {
+  let data = '';
+  res.on('data', chunk => { data += chunk; });
+  res.on('end', () => { console.log('Response:', res.statusCode, data); });
+});
+
+req.on('error', err => { console.error('Request error:', err.message); });
+req.end();


### PR DESCRIPTION
## Summary
- support `.env` file in `get_tuya_token.js`
- provide `.env.example` and ignore `.env`
- document usage of `.env` in README

## Testing
- `node get_tuya_token.js` *(fails: getaddrinfo ENOTFOUND openapi.tuyaeu.com)*