### PR TITLE
Add dotenv support for Tuya token script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+TUYA_CLIENT_ID=your-client-id
+TUYA_CLIENT_SECRET=your-client-secret
+# Optional: region code like eu, us, cn
+TUYA_REGION=eu

--- a/README.md
+++ b/README.md
@@ -48,7 +48,15 @@ Avo Demometer er et eksempel på hvordan fysiske, digitale og skybaserte løsnin
 
 ## Hente access token fra Tuya med Node.js
 
-For å hente en access token programmatisk kan du bruke skriptet `get_tuya_token.js` i dette repoet. Sett miljøvariablene `TUYA_CLIENT_ID` og `TUYA_CLIENT_SECRET` før du kjører skriptet.
+For å hente en access token programmatisk kan du bruke skriptet `get_tuya_token.js` i dette repoet. Miljøvariablene kan legges i en `.env`-fil. Kopier først eksempelfilen og fyll inn dine verdier:
+
+```bash
+cp .env.example .env
+# rediger .env og legg inn dine Tuya-verdier
+node get_tuya_token.js
+```
+
+Du kan også sette variablene direkte i miljøet før du kjører skriptet:
 
 ```bash
 export TUYA_CLIENT_ID=din_client_id

--- a/get_tuya_token.js
+++ b/get_tuya_token.js
@@ -1,5 +1,27 @@
 const crypto = require('crypto');
 const https = require('https');
+const fs = require('fs');
+const path = require('path');
+
+// Load environment variables from .env if it exists
+try {
+  const envPath = path.join(__dirname, '.env');
+  if (fs.existsSync(envPath)) {
+    const envContent = fs.readFileSync(envPath, 'utf8');
+    envContent.split(/\r?\n/).forEach(line => {
+      const match = line.match(/^\s*([A-Za-z0-9_]+)\s*=\s*(.*)\s*$/);
+      if (match) {
+        const key = match[1];
+        const value = match[2];
+        if (!process.env[key]) {
+          process.env[key] = value;
+        }
+      }
+    });
+  }
+} catch (err) {
+  console.warn('Could not load .env file:', err.message);
+}
 
 const region = process.env.TUYA_REGION || 'eu';
 const clientId = process.env.TUYA_CLIENT_ID;


### PR DESCRIPTION
## Summary
- load a `.env` file in `get_tuya_token.js` when present
- document using `.env` in the README
- add `.env.example` with placeholders for Tuya credentials

## Testing
- `node get_tuya_token.js` *(fails: getaddrinfo ENOTFOUND openapi.tuyaeu.com)*