### PR TITLE
Add Tuya request helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,18 @@ node get_tuya_token.js
 ```
 
 Skriptet beregner signaturen i henhold til Tuyas dokumentasjon og sender forespørselen til `https://openapi.tuya{region}.com/v1.0/token?grant_type=1`. Regionen kan settes via `TUYA_REGION` (f.eks. `eu`, `us` eller `cn`).
+
+## Kalle Tuya API med Node.js
+
+Når du allerede har en `access_token`, kan du bruke skriptet `tuya_request.js` til å sende egne API-kall. Skriptet tar HTTP-metoden og stien (med evt. query-parametre) som argumenter.
+
+Sett miljøvariablene `TUYA_CLIENT_ID`, `TUYA_CLIENT_SECRET` og `TUYA_ACCESS_TOKEN` først. `TUYA_REGION` kan også settes dersom du bruker et annet område enn `eu`.
+
+```bash
+export TUYA_CLIENT_ID=din_client_id
+export TUYA_CLIENT_SECRET=din_client_secret
+export TUYA_ACCESS_TOKEN=din_access_token
+node tuya_request.js GET /v1.0/devices
+```
+
+Du kan også sende en JSON-body ved å oppgi den som tredje argument. Signeringen skjer automatisk basert på parametrene du oppgir.

--- a/tuya_request.js
+++ b/tuya_request.js
@@ -1,0 +1,69 @@
+const crypto = require('crypto');
+const https = require('https');
+
+const method = (process.argv[2] || '').toUpperCase();
+const pathWithQuery = process.argv[3];
+const bodyArg = process.argv[4] || '';
+
+if (!method || !pathWithQuery) {
+  console.error('Usage: node tuya_request.js <METHOD> <PATH_WITH_QUERY> [BODY]');
+  process.exit(1);
+}
+
+const region = process.env.TUYA_REGION || 'eu';
+const clientId = process.env.TUYA_CLIENT_ID;
+const secret = process.env.TUYA_CLIENT_SECRET;
+const accessToken = process.env.TUYA_ACCESS_TOKEN;
+
+if (!clientId || !secret || !accessToken) {
+  console.error('Set TUYA_CLIENT_ID, TUYA_CLIENT_SECRET and TUYA_ACCESS_TOKEN env vars');
+  process.exit(1);
+}
+
+const body = bodyArg;
+const bodyHash = crypto.createHash('sha256').update(body).digest('hex');
+
+const stringToSign = [method, bodyHash, '', pathWithQuery].join('\n');
+const t = Date.now().toString();
+const str = clientId + accessToken + t + stringToSign;
+const signature = crypto.createHmac('sha256', secret).update(str).digest('hex').toUpperCase();
+
+const options = {
+  hostname: `openapi.tuya${region}.com`,
+  path: pathWithQuery,
+  method,
+  headers: {
+    'client_id': clientId,
+    'access_token': accessToken,
+    't': t,
+    'sign_method': 'HMAC-SHA256',
+    'sign': signature
+  }
+};
+
+if (body) {
+  options.headers['Content-Type'] = 'application/json';
+  options.headers['Content-Length'] = Buffer.byteLength(body);
+}
+
+console.log('Request options:', options);
+if (body) console.log('Request body:', body);
+
+const req = https.request(options, res => {
+  let data = '';
+  res.on('data', chunk => {
+    data += chunk;
+  });
+  res.on('end', () => {
+    console.log('Response:', res.statusCode, data);
+  });
+});
+
+req.on('error', err => {
+  console.error('Request error:', err.message);
+});
+
+if (body) {
+  req.write(body);
+}
+req.end();


### PR DESCRIPTION
## Summary
- add `tuya_request.js` to sign and send Tuya API calls
- document how to use it in README

## Testing
- `node tuya_request.js GET /v1.0/devices` *(fails: getaddrinfo ENOTFOUND)*