### PR TITLE
Add dotenv support for credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example configuration for Tuya API credentials
+TUYA_CLIENT_ID=your_client_id
+TUYA_CLIENT_SECRET=your_client_secret
+# Optional: set region if not using EU
+# TUYA_REGION=us

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Ignore environment files
+.env
+
+# Node modules and logs
+node_modules/
+npm-debug.log*
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -45,3 +45,28 @@ Kan videreutvikles med flere effekter, farger, dashboards og integrasjoner.
 
 Oppsummering
 Avo Demometer er et eksempel på hvordan fysiske, digitale og skybaserte løsninger kan spille sammen for å skape både innsikt, synlighet og engasjement på arbeidsplassen – hele veien fra CRM, via automasjon, til fysisk visualisering og selvhelbredende teknologi.
+
+## Hente access token fra Tuya med Node.js
+
+For å hente en access token programmatisk kan du bruke skriptet `get_tuya_token.js` i dette repoet. Sett miljøvariablene `TUYA_CLIENT_ID` og `TUYA_CLIENT_SECRET` før du kjører skriptet.
+
+```bash
+export TUYA_CLIENT_ID=din_client_id
+export TUYA_CLIENT_SECRET=din_client_secret
+node get_tuya_token.js
+```
+
+Skriptet beregner signaturen i henhold til Tuyas dokumentasjon og sender forespørselen til `https://openapi.tuya{region}.com/v1.0/token?grant_type=1`. Regionen kan settes via `TUYA_REGION` (f.eks. `eu`, `us` eller `cn`).
+
+### Miljøvariabler med .env
+
+Du kan også legge inn Tuya-verdiene dine i en `.env`-fil.
+Kopier eksempelfilen og fyll inn dine egne nøkler:
+
+```bash
+cp .env.example .env
+# rediger .env og oppdater TUYA_CLIENT_ID, TUYA_CLIENT_SECRET og eventuelt TUYA_REGION
+npm install
+node get_tuya_token.js
+```
+

--- a/get_tuya_token.js
+++ b/get_tuya_token.js
@@ -1,0 +1,54 @@
+const crypto = require('crypto');
+const https = require('https');
+// Load environment variables from .env if available
+try {
+  require('dotenv').config();
+} catch (err) {
+  if (err.code !== 'MODULE_NOT_FOUND') {
+    console.warn('dotenv load error:', err.message);
+  }
+}
+
+const region = process.env.TUYA_REGION || 'eu';
+const clientId = process.env.TUYA_CLIENT_ID;
+const secret = process.env.TUYA_CLIENT_SECRET;
+
+if (!clientId || !secret) {
+  console.error('Set TUYA_CLIENT_ID and TUYA_CLIENT_SECRET environment variables');
+  process.exit(1);
+}
+
+const HTTP_METHOD = 'GET';
+const PATH_WITH_QUERY = '/v1.0/token?grant_type=1';
+const NULL_HASH = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+
+const t = Date.now().toString();
+const stringToSign = [HTTP_METHOD, NULL_HASH, '', PATH_WITH_QUERY].join('\n');
+const str = clientId + t + '' + stringToSign;
+
+const hmac = crypto.createHmac('sha256', secret);
+hmac.update(str);
+const signature = hmac.digest('hex').toUpperCase();
+
+const options = {
+  hostname: `openapi.tuya${region}.com`,
+  path: PATH_WITH_QUERY,
+  method: HTTP_METHOD,
+  headers: {
+    'client_id': clientId,
+    't': t,
+    'sign_method': 'HMAC-SHA256',
+    'sign': signature
+  }
+};
+
+console.log('Request options:', options);
+
+const req = https.request(options, res => {
+  let data = '';
+  res.on('data', chunk => { data += chunk; });
+  res.on('end', () => { console.log('Response:', res.statusCode, data); });
+});
+
+req.on('error', err => { console.error('Request error:', err.message); });
+req.end();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "demometer",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "dotenv": "^16.4.0"
+  }
+}


### PR DESCRIPTION
## Summary
- allow `get_tuya_token.js` to load environment variables from `.env`
- document how to use a `.env` file and add sample `.env.example`
- add `.gitignore` and `package.json` declaring a `dotenv` dependency

## Testing
- `node get_tuya_token.js` *(fails: Set TUYA_CLIENT_ID and TUYA_CLIENT_SECRET environment variables)*